### PR TITLE
Fix readme.md to start docker-compose with profile (Linux)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ Install [Ollama](https://ollama.ai) in MacOS and start it before running `docker
 
 **Linux**
 No need to install Ollama manually, it will run in a container as
-part of the stack when running with the Linus profile: `run docker compose up --profile linux`.
+part of the stack when running with the Linus profile: `run docker compose --profile linux up`.
 
 **Windows**
 Not supported by Ollama, so Windows users need to generate a OpenAI API key and configure the stack to use `gpt-3.5` or `gpt-4` in the `.env` file.


### PR DESCRIPTION
The Readme.md states to run `docker compose up --profile linux` on linux. Instead it must be `docker compose --profile linux up`.

Relates to this issue: https://github.com/docker/genai-stack/issues/17 