### PR TITLE
Fix missing default for LLM env var

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       dockerfile: pull_model.Dockerfile
     environment:
       - OLLAMA_BASE_URL=${OLLAMA_BASE_URL-http://host.docker.internal:11434}
-      - LLM
+      - LLM=${LLM-llama2}
     networks:
       - net
 


### PR DESCRIPTION
Not sure I'm missing something. But this change (or setting the env var) was necessary for me to get the stack to work.