### PR TITLE
Added api dependency on pull-model

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -164,6 +164,8 @@ services:
     depends_on:
       database:
         condition: service_healthy
+      pull-model:
+        condition: service_completed_successfully
     x-develop:
       watch:
         - action: rebuild


### PR DESCRIPTION
I added a dependency between the `api` and `pull-model` services like the other bots.  This should avoid `unable to connect` errors if people try to connect before pulling the model is over.