### PR TITLE
Display pull progress bar with docker compose up

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - LLM=${LLM-llama2}
     networks:
       - net
+    tty: true
 
   database:
     image: neo4j:5.11


### PR DESCRIPTION
I realized that using `docker compose logs` showed the pull progress bar, but not while using `docker compose up`.

I added the `tty: true` parameter so that the full log of the pull-model service is displayed (including the pull progresss bar). It is not very "nice" as the colorful output of the `docker compose up` isn't there for this service, but it allows to see the progress bar.

Do you think it is worth it ?