### PR TITLE
Add healthcheck to api service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -189,6 +189,11 @@ services:
             - front-end/
     ports:
       - 8504:8504
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 http://localhost:8504/ || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
   front-end:
     build:


### PR DESCRIPTION
docker compose up was failing to start the api service.  
Added a healthcheck to the service to allow it to start properly.

```bash
❯ docker compose up
genai-stack-pull-model-1 exited with code 0
dependency failed to start: container genai-stack-api-1 has no healthcheck configured
```