### PR TITLE
Add linux-gpu profile to enable GPU support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,21 @@
 services:
 
-  llm:
+  llm: &llm
     image: ollama/ollama:latest
     profiles: ["linux"]
     networks:
       - net
+
+  llm-gpu:
+    <<: *llm
+    profiles: ["linux-gpu"]
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
 
   pull-model:
     image: genai-stack/pull-model:latest

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,8 @@ No need to install Ollama manually, it will run in a container as
 part of the stack when running with the Linux profile: run `docker compose --profile linux up`.
 Make sure to set the `OLLAMA_BASE_URL=http://llm:11434` in the `.env` file when using Ollama docker container.
 
+To use the Linux-GPU profile: run `docker compose --profile linux-gpu up`. Also change `OLLAMA_BASE_URL=http://llm-gpu:11434` in the `.env` file.
+
 **Windows**
 Not supported by Ollama, so Windows users need to generate a OpenAI API key and configure the stack to use `gpt-3.5` or `gpt-4` in the `.env` file.
 # Develop


### PR DESCRIPTION
This is probably the solution of this issue: #62.

I added some deploy resources to allow GPU access of service `llm-gpu`. For now, I have created a new profile `linux-gpu` associated with `llm-gpu` service as if there is no GPU, the stack can't start.