### PR TITLE
Fix KeyError: 'ollama_base_url'

### DIFF
--- a/api.py
+++ b/api.py
@@ -36,7 +36,7 @@ os.environ["NEO4J_URL"] = url
 
 embeddings, dimension = load_embedding_model(
     embedding_model_name,
-    config={ollama_base_url: ollama_base_url},
+    config={"ollama_base_url": ollama_base_url},
     logger=BaseLogger(),
 )
 


### PR DESCRIPTION
When EMBEDDING_MODEL is set to ollama in .env file

```
EMBEDDING_MODEL=ollama #or sentence_transformer, openai, ollama, or aws
```


I got the following error message

```
genai-stack-api-1         |   File "/usr/local/lib/python3.11/importlib/__init__.py", line 126, in import_module
genai-stack-api-1         |     return _bootstrap._gcd_import(name[level:], package, level)
genai-stack-api-1         |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
genai-stack-api-1         |   File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
genai-stack-api-1         |   File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
genai-stack-api-1         |   File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
genai-stack-api-1         |   File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
genai-stack-api-1         |   File "<frozen importlib._bootstrap_external>", line 940, in exec_module
genai-stack-api-1         |   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
genai-stack-api-1         |   File "/app/api.py", line 37, in <module>
genai-stack-api-1         |     embeddings, dimension = load_embedding_model(
genai-stack-api-1         |                             ^^^^^^^^^^^^^^^^^^^^^
genai-stack-api-1         |   File "/app/chains.py", line 23, in load_embedding_model
genai-stack-api-1         |     base_url=config["ollama_base_url"], model="llama2"
genai-stack-api-1         |              ~~~~~~^^^^^^^^^^^^^^^^^^^
genai-stack-api-1         | KeyError: 'ollama_base_url'
```

And there is one typo in api.py
