### PR TITLE
Fixes loader healthcheck 

### DIFF
--- a/loader.Dockerfile
+++ b/loader.Dockerfile
@@ -19,6 +19,6 @@ COPY images ./images
 
 EXPOSE 8502
 
-HEALTHCHECK CMD curl --fail http://localhost:8501/_stcore/health
+HEALTHCHECK CMD curl --fail http://localhost:8502/_stcore/health
 
 ENTRYPOINT ["streamlit", "run", "loader.py", "--server.port=8502", "--server.address=0.0.0.0"]


### PR DESCRIPTION
The `HEALTHCHECK` should be against exposed port `8502` instead of `8501`