### PR TITLE
Relocate the streamlit chat box hidden behind "Select RAG mode" pane

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -72,6 +72,10 @@ styl = f"""
     textarea[aria-label="Description"] {{
         height: 200px;
     }}
+
+    .element-container:has([aria-label="What coding issue can I help you resolve today?"]) {{
+        bottom: 45px;
+    }} 
 </style>
 """
 st.markdown(styl, unsafe_allow_html=True)


### PR DESCRIPTION
The text box is hidden behind the "Select RAG mode" pane.

<img width="1768" alt="hidden-chat-box" src="https://github.com/docker/genai-stack/assets/11523154/bdd32908-9bd2-4f78-b74a-a47c404a06e5">

Update the streamlit style sheet to relocate the chat text bottom above the pane.

<img width="1776" alt="displayed-chat-box" src="https://github.com/docker/genai-stack/assets/11523154/244b9ec4-a75f-4745-b83c-c6dcf46ad780">

This change tries to solve the following reported issue:
https://github.com/docker/genai-stack/issues/144