### PR TITLE
Add environment variable to front-end (bot-ui) for api (bot-api)

### DIFF
--- a/env.example
+++ b/env.example
@@ -27,6 +27,11 @@ EMBEDDING_MODEL=sentence_transformer #or google-genai-embedding-001 openai, olla
 #OLLAMA_BASE_URL=http://host.docker.internal:11434
 
 #*****************************************************************
+# Fronted Bot UI
+#*****************************************************************
+#VITE_API_BASE_URL=http://localhost:8504
+
+#*****************************************************************
 # OpenAI
 #*****************************************************************
 # Only required when using OpenAI LLM or embedding model

--- a/front-end/src/lib/chat.store.js
+++ b/front-end/src/lib/chat.store.js
@@ -1,6 +1,7 @@
 import { writable } from "svelte/store";
 
-const API_ENDPOINT = "http://localhost:8504/query-stream";
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:8504";
+const API_ENDPOINT = API_BASE_URL + "/query-stream";
 
 export const chatStates = {
     IDLE: "idle",

--- a/front-end/src/lib/generation.store.js
+++ b/front-end/src/lib/generation.store.js
@@ -1,6 +1,7 @@
 import { writable } from "svelte/store";
 
-const API_ENDPOINT = "http://localhost:8504/generate-ticket";
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:8504";
+const API_ENDPOINT = API_BASE_URL + "/generate-ticket";
 
 export const generationStates = {
     IDLE: "idle",

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,7 @@ Available variables:
 | AWS_DEFAULT_REGION     |                                    | REQUIRED - Only if LLM=claudev2 or embedding_model=aws                  |
 | OPENAI_API_KEY         |                                    | REQUIRED - Only if LLM=gpt-4 or LLM=gpt-3.5 or embedding_model=openai   |
 | GOOGLE_API_KEY         |                                    | REQUIRED - Only required when using GoogleGenai LLM or embedding model google-genai-embedding-001|
+| PUBLIC_API_BASE_URL    | http://localhost:8504              | OPTIONAL - URL to the Bot API endpoint                                  |
 | LANGCHAIN_ENDPOINT     | "https://api.smith.langchain.com"  | OPTIONAL - URL to Langchain Smith API                                   |
 | LANGCHAIN_TRACING_V2   | false                              | OPTIONAL - Enable Langchain tracing v2                                  |
 | LANGCHAIN_PROJECT      |                                    | OPTIONAL - Langchain project name                                       |


### PR DESCRIPTION
The front-end javascript app is hardcoded to `http://localhost:8504` but this does not leave room for customisation on the port number or the host (for example, at release.com we can deploy this stack on a customer's cloud for them to test). This patch should allow you to create an environment variable at static build or runtime to configure the location of the bot's api endpoint.

Any questions or concerns, let me know. I hope this conforms to submission guidelines and tests, etc.