### PR TITLE
Add fix for pull-model $HOME panic.

### DIFF
--- a/pull_model.Dockerfile
+++ b/pull_model.Dockerfile
@@ -26,7 +26,7 @@ COPY <<EOF pull_model.clj
         (async/go-loop [n 0]
           (let [[v _] (async/alts! [done (async/timeout 5000)])]
             (if (= :stop v) :stopped (do (println (format "... pulling model (%ss) - will take several minutes" (* n 10))) (recur (inc n))))))
-        (process/shell {:env {"OLLAMA_HOST" url} :out :inherit :err :inherit} (format "bash -c './bin/ollama show %s --modelfile > /dev/null || ./bin/ollama pull %s'" llm llm))
+        (process/shell {:env {"OLLAMA_HOST" url "HOME" (System/getProperty "user.home")} :out :inherit :err :inherit} (format "bash -c './bin/ollama show %s --modelfile > /dev/null || ./bin/ollama pull %s'" llm llm))
         (async/>!! done :stop))
 
       (println "OLLAMA model only pulled if both LLM and OLLAMA_BASE_URL are set and the LLM model is not gpt")))


### PR DESCRIPTION
References:
https://github.com/docker/genai-stack/issues/176
https://github.com/samchenghowing/Web-Study-Platform-with-GenAI-Stack/commit/437ad2a0dfd3d52a310c9bcff211eabe6ed1b799

There is a fix for this mentioned in #175 but it doesn't seem to be added. This is a minimal change to add this fix to main.