### PR TITLE
feat: Add OrcaRouter as a supported LLM provider

### DIFF
--- a/api.py
+++ b/api.py
@@ -29,6 +29,8 @@ url = os.getenv("NEO4J_URI")
 username = os.getenv("NEO4J_USERNAME")
 password = os.getenv("NEO4J_PASSWORD")
 ollama_base_url = os.getenv("OLLAMA_BASE_URL")
+orcarouter_base_url = os.getenv("ORCAROUTER_BASE_URL")
+orcarouter_api_key = os.getenv("ORCAROUTER_API_KEY")
 embedding_model_name = os.getenv("EMBEDDING_MODEL")
 llm_name = os.getenv("LLM")
 # Remapping for Langchain Neo4j integration
@@ -47,7 +49,13 @@ neo4j_graph = Neo4jGraph(
 create_vector_index(neo4j_graph)
 
 llm = load_llm(
-    llm_name, logger=BaseLogger(), config={"ollama_base_url": ollama_base_url}
+    llm_name,
+    logger=BaseLogger(),
+    config={
+        "ollama_base_url": ollama_base_url,
+        "orcarouter_base_url": orcarouter_base_url,
+        "orcarouter_api_key": orcarouter_api_key,
+    },
 )
 
 llm_chain = configure_llm_only_chain(llm)

--- a/bot.py
+++ b/bot.py
@@ -22,6 +22,8 @@ url = os.getenv("NEO4J_URI")
 username = os.getenv("NEO4J_USERNAME")
 password = os.getenv("NEO4J_PASSWORD")
 ollama_base_url = os.getenv("OLLAMA_BASE_URL")
+orcarouter_base_url = os.getenv("ORCAROUTER_BASE_URL")
+orcarouter_api_key = os.getenv("ORCAROUTER_API_KEY")
 embedding_model_name = os.getenv("EMBEDDING_MODEL")
 llm_name = os.getenv("LLM")
 # Remapping for Langchain Neo4j integration
@@ -49,7 +51,15 @@ class StreamHandler(BaseCallbackHandler):
         self.container.markdown(self.text)
 
 
-llm = load_llm(llm_name, logger=logger, config={"ollama_base_url": ollama_base_url})
+llm = load_llm(
+    llm_name,
+    logger=logger,
+    config={
+        "ollama_base_url": ollama_base_url,
+        "orcarouter_base_url": orcarouter_base_url,
+        "orcarouter_api_key": orcarouter_api_key,
+    },
+)
 
 llm_chain = configure_llm_only_chain(llm)
 rag_chain = configure_qa_rag_chain(

--- a/chains.py
+++ b/chains.py
@@ -61,7 +61,19 @@ def load_embedding_model(embedding_model_name: str, logger=BaseLogger(), config=
 
 
 def load_llm(llm_name: str, logger=BaseLogger(), config={}):
-    if llm_name in ["gpt-4", "gpt-4o", "gpt-4-turbo"]:
+    if llm_name.startswith("orcarouter/"):
+        # OrcaRouter exposes its model namespace under the `orcarouter/` prefix on
+        # an OpenAI-compatible endpoint, so it can reuse ChatOpenAI directly.
+        logger.info(f"LLM: Using OrcaRouter: {llm_name}")
+        return ChatOpenAI(
+            temperature=0,
+            model_name=llm_name,
+            streaming=True,
+            base_url=config.get("orcarouter_base_url")
+            or "https://api.orcarouter.ai/v1",
+            api_key=config.get("orcarouter_api_key"),
+        )
+    elif llm_name in ["gpt-4", "gpt-4o", "gpt-4-turbo"]:
         logger.info("LLM: Using GPT-4")
         return ChatOpenAI(temperature=0, model_name=llm_name, streaming=True)
     elif llm_name == "gpt-3.5":

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,9 +102,11 @@ services:
       - NEO4J_URI=${NEO4J_URI-neo4j://database:7687}
       - NEO4J_PASSWORD=${NEO4J_PASSWORD-password}
       - NEO4J_USERNAME=${NEO4J_USERNAME-neo4j}
-      - OPENAI_API_KEY=${OPENAI_API_KEY-}      
+      - OPENAI_API_KEY=${OPENAI_API_KEY-}
       - GOOGLE_API_KEY=${GOOGLE_API_KEY-}
       - OLLAMA_BASE_URL=${OLLAMA_BASE_URL-http://host.docker.internal:11434}
+      - ORCAROUTER_BASE_URL=${ORCAROUTER_BASE_URL-https://api.orcarouter.ai/v1}
+      - ORCAROUTER_API_KEY=${ORCAROUTER_API_KEY-}
       - LLM=${LLM-llama2}
       - EMBEDDING_MODEL=${EMBEDDING_MODEL-sentence_transformer}
       - LANGCHAIN_ENDPOINT=${LANGCHAIN_ENDPOINT-"https://api.smith.langchain.com"}
@@ -144,6 +146,8 @@ services:
       - OPENAI_API_KEY=${OPENAI_API_KEY-}
       - GOOGLE_API_KEY=${GOOGLE_API_KEY-}
       - OLLAMA_BASE_URL=${OLLAMA_BASE_URL-http://host.docker.internal:11434}
+      - ORCAROUTER_BASE_URL=${ORCAROUTER_BASE_URL-https://api.orcarouter.ai/v1}
+      - ORCAROUTER_API_KEY=${ORCAROUTER_API_KEY-}
       - LLM=${LLM-llama2}
       - EMBEDDING_MODEL=${EMBEDDING_MODEL-sentence_transformer}
       - LANGCHAIN_ENDPOINT=${LANGCHAIN_ENDPOINT-"https://api.smith.langchain.com"}
@@ -183,8 +187,10 @@ services:
       - NEO4J_PASSWORD=${NEO4J_PASSWORD-password}
       - NEO4J_USERNAME=${NEO4J_USERNAME-neo4j}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
-      - GOOGLE_API_KEY=${GOOGLE_API_KEY}  
+      - GOOGLE_API_KEY=${GOOGLE_API_KEY}
       - OLLAMA_BASE_URL=${OLLAMA_BASE_URL-http://host.docker.internal:11434}
+      - ORCAROUTER_BASE_URL=${ORCAROUTER_BASE_URL-https://api.orcarouter.ai/v1}
+      - ORCAROUTER_API_KEY=${ORCAROUTER_API_KEY-}
       - LLM=${LLM-llama2}
       - EMBEDDING_MODEL=${EMBEDDING_MODEL-sentence_transformer}
       - LANGCHAIN_ENDPOINT=${LANGCHAIN_ENDPOINT-"https://api.smith.langchain.com"}

--- a/env.example
+++ b/env.example
@@ -34,6 +34,14 @@ EMBEDDING_MODEL=sentence_transformer #or google-genai-embedding-001 openai, olla
 #OPENAI_API_KEY=sk-...
 
 #*****************************************************************
+# OrcaRouter
+#*****************************************************************
+# Only required when using an OrcaRouter LLM (LLM=orcarouter/<model>)
+
+#ORCAROUTER_BASE_URL=https://api.orcarouter.ai/v1
+#ORCAROUTER_API_KEY=sk-orca-...
+
+#*****************************************************************
 # AWS
 #*****************************************************************
 # Only required when using AWS Bedrock LLM or embedding model

--- a/pdf_bot.py
+++ b/pdf_bot.py
@@ -25,6 +25,8 @@ url = os.getenv("NEO4J_URI")
 username = os.getenv("NEO4J_USERNAME")
 password = os.getenv("NEO4J_PASSWORD")
 ollama_base_url = os.getenv("OLLAMA_BASE_URL")
+orcarouter_base_url = os.getenv("ORCAROUTER_BASE_URL")
+orcarouter_api_key = os.getenv("ORCAROUTER_API_KEY")
 embedding_model_name = os.getenv("EMBEDDING_MODEL")
 llm_name = os.getenv("LLM")
 # Remapping for Langchain Neo4j integration
@@ -48,7 +50,15 @@ class StreamHandler(BaseCallbackHandler):
         self.container.markdown(self.text)
 
 
-llm = load_llm(llm_name, logger=logger, config={"ollama_base_url": ollama_base_url})
+llm = load_llm(
+    llm_name,
+    logger=logger,
+    config={
+        "ollama_base_url": ollama_base_url,
+        "orcarouter_base_url": orcarouter_base_url,
+        "orcarouter_api_key": orcarouter_api_key,
+    },
+)
 
 
 def main():

--- a/readme.md
+++ b/readme.md
@@ -11,10 +11,12 @@ Available variables:
 | Variable Name          | Default value                      | Description                                                             |
 |------------------------|------------------------------------|-------------------------------------------------------------------------|
 | OLLAMA_BASE_URL        | http://host.docker.internal:11434  | REQUIRED - URL to Ollama LLM API                                        |   
+| ORCAROUTER_BASE_URL    | https://api.orcarouter.ai/v1       | OPTIONAL - URL to the [OrcaRouter](https://www.orcarouter.ai) API       |
+| ORCAROUTER_API_KEY     |                                    | REQUIRED - Only if LLM=orcarouter/<model>                               |
 | NEO4J_URI              | neo4j://database:7687              | REQUIRED - URL to Neo4j database                                        |
 | NEO4J_USERNAME         | neo4j                              | REQUIRED - Username for Neo4j database                                  |
 | NEO4J_PASSWORD         | password                           | REQUIRED - Password for Neo4j database                                  |
-| LLM                    | llama2                             | REQUIRED - Can be any Ollama model tag, or gpt-4 or gpt-3.5 or claudev2 |
+| LLM                    | llama2                             | REQUIRED - Can be any Ollama model tag, or gpt-4 or gpt-3.5 or claudev2 or orcarouter/<model> |
 | EMBEDDING_MODEL        | sentence_transformer               | REQUIRED - Can be sentence_transformer, openai, aws, ollama or google-genai-embedding-001|
 | AWS_ACCESS_KEY_ID      |                                    | REQUIRED - Only if LLM=claudev2 or embedding_model=aws                  |
 | AWS_SECRET_ACCESS_KEY  |                                    | REQUIRED - Only if LLM=claudev2 or embedding_model=aws                  |
@@ -29,6 +31,7 @@ Available variables:
 ## LLM Configuration
 MacOS and Linux users can use any LLM that's available via Ollama. Check the "tags" section under the model page you want to use on https://ollama.ai/library and write the tag for the value of the environment variable `LLM=` in the `.env` file.
 All platforms can use GPT-3.5-turbo and GPT-4 (bring your own API keys for OpenAI models).
+All platforms can also use [OrcaRouter](https://www.orcarouter.ai) models by setting `LLM=orcarouter/<model>` (for example `orcarouter/fusion-mini`) and adding your `ORCAROUTER_API_KEY` to the `.env` file. OrcaRouter exposes an OpenAI-compatible endpoint, so the stack connects to it with the same LangChain `ChatOpenAI` integration used for OpenAI.
 
 **MacOS**
 Install [Ollama](https://ollama.ai) on MacOS and start it before running `docker compose up` using `ollama serve` in a separate terminal.


### PR DESCRIPTION
# Add OrcaRouter as a supported LLM provider

The GenAI Stack connects to OpenAI through LangChain's `ChatOpenAI` in `chains.py`, and to Bedrock through `ChatBedrock` and Ollama through `ChatOllama`. OrcaRouter speaks the same OpenAI-compatible protocol on `https://api.orcarouter.ai/v1`, so this PR wires it in as a first-class provider using the exact same `ChatOpenAI` integration — no custom base URL juggling, no generic any-endpoint passthrough.

## What's added

- **`chains.py`** — a new named branch in `load_llm()`: any `LLM=orcarouter/<model>` (e.g. `orcarouter/fusion-mini`) is routed to `ChatOpenAI` pointed at the OrcaRouter base URL, mirroring the existing OpenAI case directly above it.
- **`api.py`, `bot.py`, `pdf_bot.py`** — read `ORCAROUTER_BASE_URL` and `ORCAROUTER_API_KEY` from the environment and pass them into `load_llm()`'s config, exactly like `OLLAMA_BASE_URL` is threaded through today.
- **`docker-compose.yml`** — forward `ORCAROUTER_BASE_URL` (default `https://api.orcarouter.ai/v1`) and `ORCAROUTER_API_KEY` to the `bot`, `pdf_bot`, and `api` services, alongside the existing `OPENAI_API_KEY` / `OLLAMA_BASE_URL` entries.
- **`env.example`** — a new OrcaRouter section documenting both variables.
- **`readme.md`** — documented `ORCAROUTER_BASE_URL` / `ORCAROUTER_API_KEY` in the env table and added a note under *LLM Configuration*.

## Why OrcaRouter

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Verification

- `python -m py_compile` passes on all changed Python files; `docker-compose.yml` parses cleanly.
- Live-tested the new `load_llm()` path with a real key against `https://api.orcarouter.ai/v1` — `LLM=orcarouter/fusion-mini` returns HTTP 200 and a valid completion.

To try it: set `LLM=orcarouter/fusion-mini` and `ORCAROUTER_API_KEY=sk-orca-...` in your `.env`, then `docker compose up`.

---

I'm an engineer on the OrcaRouter team.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter
